### PR TITLE
correct user account.create call

### DIFF
--- a/src/app/store/account/index.ts
+++ b/src/app/store/account/index.ts
@@ -95,6 +95,7 @@ export class AccountState {
     let { email, password, name } = action.payload;
     try {
       let account = await Api.provider().account.create(
+        'unique()',
         email,
         password,
         name


### PR DESCRIPTION
From v0.12.0 all resources with custom ID must be specified or pass in unique()